### PR TITLE
[codex] Export WebGL figure initializer

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "files": [
     "lib/**/*.js",
     "dist/*.js",
-    "css/*.css"
+    "css/*.css",
+    "shaders/*.glsl"
   ],
   "homepage": "https://github.com/bqplot/bqplot-gl",
   "bugs": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,3 +12,4 @@ export * from './ScatterGLView';
 export * from './ScatterGLModel';
 export * from './LinesGLView';
 export * from './LinesGLModel';
+export * from './utils';


### PR DESCRIPTION
This is a small support PR for downstream bqplot WebGL widget packages.

bqplot 0.13 moved the shared WebGL figure renderer setup into bqplot-gl. Downstream packages such as bqplot-image-gl need to initialize that shared renderer when they render their own WebGL marks, but the initializer currently lives in an internal module and is not exported from the package entry point.

This PR exports the existing WebGL figure initialization utilities from the frontend entry point so downstream widget bundles can call the same setup path as bqplot-gl marks. It also includes GLSL shader sources in the npm package files list. Without those shader files, downstream package builds that install bqplot-gl from npm can fail while resolving raw-loader imports such as ../shaders/scales.glsl.

Validation:
- jlpm run build:lib
- jlpm run build:nbextension

The nbextension build completed with existing source-map and bundle-size warnings, but no errors. This PR is opened as a draft because we want to demonstrate the downstream bqplot-image-gl fix against this branch before marking it ready.