### PR TITLE
ci: publish via trusted publishers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
     branches: [ master ]
   pull_request:
     branches: '*'
+  release:
+    types: [published]
 
 env:
   PIP_DISABLE_PIP_VERSION_CHECK: 1
@@ -53,10 +55,20 @@ jobs:
     - name: Build Python package
       run: python -m build
 
+    - name: Twine check
+      run: |
+        pip install --upgrade twine
+        twine check dist/*.whl dist/*.tar.gz
+
+    - name: Pack JavaScript package
+      run: |
+        jlpm pack -o bqplot-gl.tgz
+        mv bqplot-gl.tgz dist/
+
     - name: Upload builds
       uses: actions/upload-artifact@v5
       with:
-        name: dist ${{ github.run_number }}
+        name: dist-${{ github.run_number }}
         path: ./dist
 
   visual-regression-tests:
@@ -78,7 +90,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: dist ${{ github.run_number }}
+          name: dist-${{ github.run_number }}
           path: ./dist
 
       - name: Install the package
@@ -118,3 +130,105 @@ jobs:
           path: |
             ui-tests/test-results
             ui-tests/playwright-report
+
+  publish-pypi:
+    runs-on: ubuntu-latest
+    needs: [build, visual-regression-tests]
+    permissions:
+      id-token: write
+    environment:
+      name: ${{ github.event_name == 'release' && 'release-pypi' || '' }}
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist-${{ github.run_number }}
+          path: ./dist
+
+      - name: Keep only PyPI artifacts
+        run: |
+          rm -f dist/*.tgz
+          ls -la dist/
+
+      - name: Verify tag matches wheel version
+        if: github.event_name == 'release'
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          WHEEL_VERSION=$(ls dist/bqplot_gl-*.whl | sed -E 's|.*/bqplot_gl-([^-]+)-.*\.whl|\1|')
+          echo "Release tag:    $TAG"
+          echo "Wheel version:  $WHEEL_VERSION"
+          if [ "$TAG" != "$WHEEL_VERSION" ]; then
+            echo "::error::Release tag '$TAG' does not match wheel version '$WHEEL_VERSION'"
+            exit 1
+          fi
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Twine check
+        run: |
+          python -m pip install --upgrade pip twine
+          twine check dist/*.whl dist/*.tar.gz
+
+      - name: Publish to PyPI (Trusted Publisher)
+        if: github.event_name == 'release'
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  publish-npm:
+    runs-on: ubuntu-latest
+    needs: [build, visual-regression-tests]
+    permissions:
+      id-token: write
+      contents: read
+    environment:
+      name: ${{ github.event_name == 'release' && 'release-npm' || '' }}
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist-${{ github.run_number }}
+          path: ./dist
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Upgrade npm to a version that supports trusted publishing
+        run: npm install -g npm@latest
+
+      - name: Show npm package version
+        run: |
+          NPM_VERSION=$(tar -xOf dist/bqplot-gl.tgz package/package.json | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).version")
+          echo "Will publish bqplot-gl@$NPM_VERSION"
+          echo "NPM_VERSION=$NPM_VERSION" >> "$GITHUB_ENV"
+
+      - name: Check npm version
+        id: npm_check
+        run: |
+          if npm view "bqplot-gl@$NPM_VERSION" version > /dev/null 2>&1; then
+            echo "already_published=true" >> "$GITHUB_OUTPUT"
+            echo "bqplot-gl@$NPM_VERSION is already on npm"
+          else
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+            echo "bqplot-gl@$NPM_VERSION not yet on npm"
+          fi
+
+      - name: Fail if releasing an already-published version
+        if: github.event_name == 'release' && steps.npm_check.outputs.already_published == 'true'
+        run: |
+          echo "::error::bqplot-gl@$NPM_VERSION is already on npm; bump package.json before releasing"
+          exit 1
+
+      - name: npm publish (dry-run)
+        if: github.event_name != 'release' && steps.npm_check.outputs.already_published == 'false'
+        run: npm publish ./dist/bqplot-gl.tgz --access public --dry-run
+
+      - name: Skip dry-run (version already published)
+        if: github.event_name != 'release' && steps.npm_check.outputs.already_published == 'true'
+        run: echo "::notice::bqplot-gl@$NPM_VERSION is already on npm; skipping dry-run. Bump package.json on a release-prep PR to exercise the full publish flow."
+
+      - name: npm publish (Trusted Publisher)
+        if: github.event_name == 'release'
+        run: npm publish ./dist/bqplot-gl.tgz --access public --provenance


### PR DESCRIPTION
## Summary

- add GitHub Release-triggered publish jobs for PyPI and npm using trusted publishing / OIDC
- reuse the dist artifact produced by the build job, including wheel, sdist, and npm tgz
- run publish jobs in dry-run/check mode on PRs and pushes; real upload happens only for `release: published`
- validate release tag vs wheel version and guard against publishing an already-existing npm version

Closes bqplot/bqplot-gl#30

## Local validation

- `git diff --check`
- Ruby YAML parse for `.github/workflows/build.yml`
- `/tmp/bqplot-gl-build-venv/bin/python -m build`
- `/tmp/bqplot-gl-build-venv/bin/python -m twine check dist/*.whl dist/*.tar.gz`
- `PATH=/tmp/bqplot-gl-build-venv/bin:$PATH jlpm pack -o bqplot-gl.tgz`
- `npm view bqplot-gl@0.1.0 version`

## One-time setup before first real release

- Create PyPI trusted publisher for project `bqplot-gl`, workflow `build.yml`, environment `release-pypi`.
- Create npm trusted publisher for package `bqplot-gl`, workflow `build.yml`, environment `release-npm`.
- Create GitHub environments `release-pypi` and `release-npm` in this repo.
